### PR TITLE
Feature/wildcard test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Stargazers][stars-shield]][stars-url]
 [![Issues][issues-shield]][issues-url]
 
-
 <!-- PROJECT LOGO -->
 <br />
 <p align="center">
@@ -23,48 +22,58 @@
 </p>
 
 <!-- ABOUT THE PROJECT -->
+
 ## About The Project
 
 Small docker setup for nginx. Utilizes [jwilder/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) and [nginx-proxy/docker-letsencrypt-nginx-proxy-companion](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion) to reload configurations and renew certificates.
 
 <!-- GETTING STARTED -->
+
 ## Getting Started Develop
 
 To get a local copy up and running follow these simple steps.
 
 ### Prerequisites
 
-* [Docker](https://docs.docker.com/get-docker/)
-* [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
 ### Installation
 
 1. Clone the repo
+
 ```sh
 git clone https://github.com/Beuterei/nginx.git
 ```
+
 2. Copy docker-compose example and edit it
+
 ```sh
 cp docker-compose.override.example.yml docker-compose.override.yml && vim docker-compose.override.yml
 ```
+
 3. Start docker-compose
+
 ```sh
 docker-compose up --build
 ```
+
 4. Navigate to `localtest.me`
 
 ### Customization
 
 1. Create a `.env` file
+
 ```sh
 touch .env
 ```
+
 2. Overwrite variables as you like (format: `{variable name}={variable value}`)
 
-| Variable | Description | Default value | Required |
-| --- | --- | --- | --- |
-| `DEFAULT_EMAIL` | Defines your default email for Let's Encrypt | none | true |
-| `PROXY_NETWORK_NAME` | Defines your proxy network name | nginxproxynet | false |
+| Variable             | Description                                  | Default value | Required |
+| -------------------- | -------------------------------------------- | ------------- | -------- |
+| `DEFAULT_EMAIL`      | Defines your default email for Let's Encrypt | none          | true     |
+| `PROXY_NETWORK_NAME` | Defines your proxy network name              | nginxproxynet | false    |
 
 ## Getting Started Production
 
@@ -72,21 +81,26 @@ To get a copy up and running follow these simple steps.
 
 ### Prerequisites
 
-* [Docker](https://docs.docker.com/get-docker/)
-* [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
 ### Installation
 
 1. Clone the repo
+
 ```sh
 git clone https://github.com/Beuterei/nginx.git --branch master
 ```
+
 2. Create a `.env.production` file
+
 ```sh
 touch .env.production
 ```
+
 3. Overwrite all variables marked under Customization as required
 4. Start docker-compose
+
 ```sh
 docker-compose --env-file ./.env.production -f docker-compose.yml -f docker-compose.production.yml up -d
 ```
@@ -94,18 +108,43 @@ docker-compose --env-file ./.env.production -f docker-compose.yml -f docker-comp
 ### Customization
 
 1. Create a `.env.production` file
+
 ```sh
 touch .env.production
 ```
+
 2. Overwrite variables as you like (format: `{variable name}={variable value}`)
 
-| Variable | Description | Default value | Required |
-| --- | --- | --- | --- |
-| `DEFAULT_EMAIL` | Defines your default email for Let's Encrypt | none | true |
-| `PROXY_NETWORK_NAME` | Defines your proxy network name | nginxproxynet | false |
+| Variable             | Description                                  | Default value | Required |
+| -------------------- | -------------------------------------------- | ------------- | -------- |
+| `DEFAULT_EMAIL`      | Defines your default email for Let's Encrypt | none          | true     |
+| `PROXY_NETWORK_NAME` | Defines your proxy network name              | nginxproxynet | false    |
+| `CF_Token`           | Cloudflare API Token (for DNS-01 challenge)  | none          | false    |
+| `CF_Account_ID`      | Cloudflare Account ID (for DNS-01 challenge) | none          | false    |
+
+### Wildcard Certificates & DNS Validation
+
+To issue wildcard certificates (e.g., `*.yourdomain.com`) or secure local domains behind a NAT using DNS validation, you can provide DNS provider credentials.
+
+1.  **Configure API Credentials**: Add the variables for your DNS provider to `.env` or `.env.production`.
+
+    - Example for Cloudflare:
+      ```env
+      CF_Token=your_token
+      CF_Account_ID=your_account_id
+      ```
+    - _Note: The token requires `Zone:Zone:Read` and `Zone:DNS:Edit` permissions._
+
+2.  **Request Wildcard Cert**: In your service configuration, request the wildcard domain.
+    ```yaml
+    environment:
+      - VIRTUAL_HOST=sub.yourdomain.com
+      - LETSENCRYPT_HOST=*.yourdomain.com
+    ```
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
 [contributors-shield]: https://img.shields.io/github/contributors/Beuterei/nginx.svg?style=flat-square
 [contributors-url]: https://github.com/Beuterei/nginx/graphs/contributors
 [forks-shield]: https://img.shields.io/github/forks/Beuterei/nginx.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ touch .env.production
 
 To issue wildcard certificates (e.g., `*.yourdomain.com`) or secure local domains behind a NAT using DNS validation, you can provide DNS provider credentials.
 
-1.  **Configure API Credentials**: Add the variables for your DNS provider to `.env` or `.env.production`.
+1.  **Configure API Credentials**: Add the variables for your DNS provider to `.env.production`.
 
     - Example for Cloudflare:
       ```env

--- a/README.md
+++ b/README.md
@@ -135,11 +135,12 @@ To issue wildcard certificates (e.g., `*.yourdomain.com`) or secure local domain
       ```
     - _Note: The token requires `Zone:Zone:Read` and `Zone:DNS:Edit` permissions._
 
-2.  **Request Wildcard Cert**: In your service configuration, request the wildcard domain.
+2.  **Request Wildcard Cert**: In your service configuration, request the wildcard domain and enable the DNS challenge.
     ```yaml
     environment:
       - VIRTUAL_HOST=sub.yourdomain.com
       - LETSENCRYPT_HOST=*.yourdomain.com
+      - ACME_CHALLENGE=DNS-01
     ```
 
 <!-- MARKDOWN LINKS & IMAGES -->

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -7,5 +7,7 @@ services:
         container_name: nginxProxyLetsEncryptProd
 
         environment:
-            CF_Token: ${CF_Token:-}
-            CF_Account_ID: ${CF_Account_ID:-}
+            ACMESH_DNS_API_CONFIG: |-
+                DNS_API: dns_cf
+                CF_Token: ${CF_Token}
+                CF_Account_ID: ${CF_Account_ID}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,3 +5,7 @@ services:
 
     letsencrypt:
         container_name: nginxProxyLetsEncryptProd
+
+        environment:
+            CF_Token: ${CF_Token:-}
+            CF_Account_ID: ${CF_Account_ID:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
     nginx-proxy:
-        image: jwilder/nginx-proxy:1.3-alpine
+        image: jwilder/nginx-proxy:1.9-alpine
 
         labels:
             - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
@@ -25,7 +25,7 @@ services:
             - /var/run/docker.sock:/tmp/docker.sock:ro
 
     letsencrypt:
-        image: nginxproxy/acme-companion:2.2
+        image: nginxproxy/acme-companion:2.6
 
         depends_on:
             - nginx-proxy


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces DNS-01 support and wildcard cert guidance, plus image bumps.
> 
> - Adds `ACMESH_DNS_API_CONFIG` to `docker-compose.production.yml` to enable DNS-01 via Cloudflare (`dns_cf`) using `CF_Token` and `CF_Account_ID`
> - Bumps images: `jwilder/nginx-proxy` to `1.9-alpine` and `nginxproxy/acme-companion` to `2.6`
> - README: formats prerequisites/tables and adds “Wildcard Certificates & DNS Validation” with Cloudflare example and new env vars in production customization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25b85e5d3f7fb1a032a9721f21bbef8f06b25a9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->